### PR TITLE
Fix memory corruption

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -314,6 +314,8 @@ int tv__tcp_connect2(tv_tcp_t* handle, tv_addrinfo_t* addr) {
   sock = socket(addr->ai->ai_addr->sa_family, SOCK_STREAM, 0);
   if (sock < 0) {
     free(connect_req);
+    /* remove the handle from the handle queue, since it was added by uv__handle_init in uv_stream_init. */
+    QUEUE_REMOVE(&uv_handle->handle_queue);
     free(uv_handle);
     handle->tcp_handle = NULL;
     return sock;


### PR DESCRIPTION
In event of socket failure, the handle is needed to be removed from the handle queue, since it was added by `uv__handle_init` in `uv_stream_init` for preventing memory corruption.

As @karlsharman  reported in #1. 

> The uv_handle is freed, but it is still linked into the handle->loop->loop linked list (it is linked into the list in the uv_tcp_init function just above).
> This causes memory corruption because the memory that was associated with uv_handle could be allocated to something else in user-space - future adjustment of the linked list will corrupt that memory.